### PR TITLE
Add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # Appli-Garde2
-Application pour facilité la garde de Neurochirurgie à Besançon 
+Application pour faciliter la garde de Neurochirurgie à Besançon.
+
+## Prerequisites
+- [Node.js](https://nodejs.org/) v18 or later
+- [Expo CLI](https://docs.expo.dev/workflow/expo-cli/)
+
+## Setup
+1. Move into the project directory:
+   ```bash
+   cd project
+   ```
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+Once the server is running, you can scan the QR code with Expo Go or
+open the project in an iOS or Android emulator to view the app.
+


### PR DESCRIPTION
## Summary
- document prerequisites and setup steps in README

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d489d7f2083309b4a5ceb59cf33c8