### PR TITLE
Fix React 19 peer conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Application pour faciliter la garde de Neurochirurgie à Besançon.
    ```bash
    npm install
    ```
+   After installation, `patch-package` will automatically adjust
+   `lucide-react-native` to work with React 19.
 3. Start the development server:
    ```bash
    npm run dev

--- a/project/package.json
+++ b/project/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "EXPO_NO_TELEMETRY=1 expo start",
     "build:web": "expo export --platform web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -44,6 +45,7 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "patch-package": "^8.0.0"
   }
 }

--- a/project/patches/lucide-react-native+0.475.0.patch
+++ b/project/patches/lucide-react-native+0.475.0.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/lucide-react-native/package.json b/node_modules/lucide-react-native/package.json
+index 1234567..89abcde 100644
+--- a/node_modules/lucide-react-native/package.json
++++ b/node_modules/lucide-react-native/package.json
+@@
+-  "peerDependencies": {
+-    "react": "^16.5.1 || ^17.0.0 || ^18.0.0",
+-    "react-native": "*",
+-    "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
+-  }
++  "peerDependencies": {
++    "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
++    "react-native": "*",
++    "react-native-svg": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
++  }
+ }


### PR DESCRIPTION
## Summary
- allow React 19 in lucide-react-native via patch-package
- add postinstall script to run patch-package
- document patch step in README

## Testing
- `npm run lint` *(fails: `expo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d511a9e708330b171e1a157e96f55