### PR TITLE
Update install guide for React 19 conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Application pour faciliter la garde de Neurochirurgie à Besançon.
    ```bash
    cd project
    ```
-2. Install dependencies:
+2. Install dependencies (use `--legacy-peer-deps` to bypass the React 19 peer conflict):
    ```bash
-   npm install
+   npm install --legacy-peer-deps
    ```
    After installation, `patch-package` will automatically adjust
    `lucide-react-native` to work with React 19.


### PR DESCRIPTION
## Summary
- document using `npm install --legacy-peer-deps` to work around lucide-react-native's peer dependency requirement

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d58e02a8c8330b3a2e16ce9897398