### PR TITLE
Add quick start helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ Application pour faciliter la garde de Neurochirurgie à Besançon.
 Once the server is running, you can scan the QR code with Expo Go or
 open the project in an iOS or Android emulator to view the app.
 
+## Quick Start Script
+
+Pour démarrer rapidement l'application, exécutez simplement :
+
+```bash
+./start.sh
+```
+
+Ce script installe les dépendances si nécessaire puis lance le serveur
+de développement Expo.
+

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Quick start script for Appli-Garde2
+# Installs dependencies and starts the development server.
+# Usage: ./start.sh
+
+set -e
+cd "$(dirname "$0")/project"
+
+npm install --legacy-peer-deps
+npm run dev


### PR DESCRIPTION
## Summary
- add a small `start.sh` helper script to set up and run the app
- document using the script in the README

## Testing
- `npm run lint` *(fails: `expo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d613381d8833098a899e13464db1e