### PR TITLE
Check node_modules before running npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Pour démarrer rapidement l'application, exécutez simplement :
 ./start.sh
 ```
 
-Ce script installe les dépendances si nécessaire puis lance le serveur
-de développement Expo.
+Ce script vérifie la présence du dossier `project/node_modules` et
+n'installe les dépendances que s'il est absent. Il lance ensuite le
+serveur de développement Expo.
 

--- a/start.sh
+++ b/start.sh
@@ -6,5 +6,7 @@
 set -e
 cd "$(dirname "$0")/project"
 
-npm install --legacy-peer-deps
+if [ ! -d node_modules ]; then
+  npm install --legacy-peer-deps
+fi
 npm run dev


### PR DESCRIPTION
## Summary
- update quick start script to skip `npm install` if dependencies are already installed
- document conditional install behaviour in README

## Testing
- `npm run lint` *(fails: `expo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d676cc1808330b28bf29a9f7a92c5